### PR TITLE
perf: reduce bundled size

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "es-toolkit": "1.39.10",
     "history": "^5.3.0",
-    "lodash": "^4.17.21",
     "qs": "^6.14.0",
     "tiny-invariant": "^1.3.3",
     "unstorage": "^1.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,12 @@ importers:
 
   .:
     dependencies:
+      es-toolkit:
+        specifier: 1.39.10
+        version: 1.39.10
       history:
         specifier: ^5.3.0
         version: 5.3.0
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
       qs:
         specifier: ^6.14.0
         version: 6.14.0
@@ -1352,6 +1352,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.39.10:
+    resolution: {integrity: sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -4413,6 +4416,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.39.10: {}
 
   esbuild-register@3.6.0(esbuild@0.25.10):
     dependencies:

--- a/src/data-manager.ts
+++ b/src/data-manager.ts
@@ -1,5 +1,5 @@
 import { parseQueryString } from './query-parser.js'
-import { get, isPlainObject } from 'lodash'
+import { get, isPlainObject } from 'es-toolkit/compat'
 import type { UrlManager } from './url-manager-interface.js'
 import type { DataManager } from './data-manager-interface.js'
 

--- a/src/storage-operations.ts
+++ b/src/storage-operations.ts
@@ -1,7 +1,7 @@
 import type { StorageValue, TransactionOptions, GetKeysOptions } from 'unstorage'
 import type { DataManager } from './data-manager-interface.js'
 import { QueryStringDriverError } from './errors.js'
-import { get, set, has, omit, keys } from 'lodash'
+import { get, set, has, omit, keys } from 'es-toolkit/compat'
 
 function isStorageValue(value: unknown): value is StorageValue {
   return value === null ||

--- a/src/url-manager.ts
+++ b/src/url-manager.ts
@@ -1,7 +1,7 @@
 import type { QueryStringDriverOptions } from './types.js'
 import type { UrlManager } from './url-manager-interface.js'
 import { QueryStringDriverError } from './errors.js'
-import validator from 'validator'
+import isURL from 'validator/lib/isURL.js'
 import invariant from 'tiny-invariant'
 
 export function createUrlManager(options: QueryStringDriverOptions): UrlManager {
@@ -13,12 +13,12 @@ export function createUrlManager(options: QueryStringDriverOptions): UrlManager 
       if (internalUrl) return internalUrl
 
       // If it's a relative URL, we need a browser environment for the origin
-      if (!validator.isURL(url) && (typeof window === 'undefined' || !window.location)) {
+      if (!isURL(url) && (typeof window === 'undefined' || !window.location)) {
         throw new QueryStringDriverError('Cannot resolve relative URL in non-browser environment')
       }
 
       try {
-        if (validator.isURL(url)) {
+        if (isURL(url)) {
           internalUrl = new URL(url)
         } else {
           internalUrl = new URL(url, window.location.origin)

--- a/src/url-updater.ts
+++ b/src/url-updater.ts
@@ -2,7 +2,7 @@ import type { QueryStringDriverOptions } from './types.js'
 import type { UrlManager } from './url-manager-interface.js'
 import { stringifyData } from './query-stringifier.js'
 import { parseQueryString } from './query-parser.js'
-import { set } from 'lodash'
+import { set } from 'es-toolkit/compat'
 
 export function createUrlUpdater(
   urlManager: UrlManager,

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -24,7 +24,7 @@ export default defineConfig(async ({ command }) => {
         fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`
       },
       rollupOptions: {
-        external: ['unstorage', 'qs', 'lodash', 'validator', 'tiny-invariant', 'history']
+        external: ['unstorage', 'qs', 'es-toolkit', 'validator', 'tiny-invariant', 'history']
       }
     }
   }


### PR DESCRIPTION
Two optimizations helped reduce bundled size of this package from 68.5 kB (brotli compressed) to 17.32 kB.

1. Using [es-toolkit](https://es-toolkit.dev), a lighter alternative to lodash with tree-shaking support, reduced final bundle size for this package from 68.5 kB to 47.47 kB
2. Limiting the import from validator to only the used function further helped to reduce the final bundle size from 47.47 kB to 17.32 kB

Bundled sizes were tested with [export-size](https://github.com/antfu/export-size#readme) with the `rollupOptions.external` option disable in the Vite configuration (to mock the final bundling of the package in an app).