### PR TITLE
Enable eqeqeq lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,12 @@ import agentConfig from 'eslint-config-agent'
 export default [
   ...agentConfig,
   {
+    rules: {
+      // Require === and !== to avoid implicit type coercion bugs.
+      eqeqeq: ['error', 'always']
+    }
+  },
+  {
     ignores: ['dist/**', 'node_modules/**']
   }
 ]

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -94,7 +94,7 @@ describe("Query String Driver", () => {
     });
 
     await storage.setItem("test", "value");
-    
+
     // Verify the data can be retrieved through the storage system
     expect(await storage.getItem("test")).toBe("value");
   });
@@ -169,7 +169,7 @@ describe("Query String Driver", () => {
     // Should only clear app prefixed keys - verify through storage
     expect(await storage.getItem("foo")).toBe(null);
     expect(await storage.getItem("baz")).toBe(null);
-    
+
     // The original non-prefixed keys should still exist in the URL
     // but they're not accessible through this storage instance with base "app"
   });


### PR DESCRIPTION
## Summary

Enables the [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) ESLint rule as `['error', 'always']` in the local ESLint config, requiring `===`/`!==` instead of the loose `==`/`!=`.

## Why

Loose equality performs implicit type coercion (`0 == ''`, `null == undefined`, `'1' == 1` all `true`), a common source of subtle bugs and ambiguous intent. Enforcing strict equality removes that whole class of bug and matches the strict-by-default style of this TypeScript codebase.

## Changes

- `eslint.config.mjs`: add `eqeqeq: ['error', 'always']`.
- `src/index.test.ts`: strip two pre-existing trailing-space errors (`no-trailing-spaces`) so `pnpm lint` passes green. No other rules touched.

## Validation

The new rule surfaces **zero** new violations — source and tests have no `==`/`!=` usage. All checks pass locally:

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` ✅ (86 tests)

Closes #4