### PR TITLE
chore: enable eqeqeq lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,12 @@ import agentConfig from 'eslint-config-agent'
 export default [
   ...agentConfig,
   {
+    rules: {
+      // Require strict equality (===/!==) to avoid implicit type coercion bugs.
+      eqeqeq: ['error', 'always']
+    }
+  },
+  {
     ignores: ['dist/**', 'node_modules/**']
   }
 ]


### PR DESCRIPTION
Enables the [`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) ESLint rule (`['error', 'always']`) in the local config, requiring strict `===`/`!==` and forbidding coercion-prone `==`/`!=`.

## Verification
- Confirmed the rule is active: a temporary `a == 2` expression now errors with `eqeqeq`.
- The source contains **zero** `==`/`!=` usages, so this introduces no new violations — purely preventative against future coercion bugs.
- `pnpm typecheck` and `pnpm test` (86 tests) pass.

> Note: `pnpm lint` reports two pre-existing `no-trailing-spaces` errors in `src/index.test.ts` (lines 97, 172) that are present on `main` and unrelated to this change; left untouched to keep this PR scoped to the issue.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)