### PR TITLE
chore(lint): enable @typescript-eslint/consistent-type-imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,10 @@ export default [
   {
     rules: {
       // Require === and !== to avoid implicit type coercion bugs.
-      eqeqeq: ['error', 'always']
+      eqeqeq: ['error', 'always'],
+      // Force `import type` for type-only imports so they are erased at
+      // compile time and never leak into the runtime bundle.
+      '@typescript-eslint/consistent-type-imports': 'error'
     }
   },
   {


### PR DESCRIPTION
## Summary

Enables the `@typescript-eslint/consistent-type-imports` rule (`error`) in `eslint.config.mjs`, layered onto the existing `eslint-config-agent` + `eqeqeq` setup.

The rule requires imports used **only as types** to be written with `import type`, guaranteeing they are erased at compile time. This avoids accidental runtime/side-effect imports, reduces circular-dependency risk, and makes erasure intent explicit. It is autofixable.

## Changes

- `eslint.config.mjs`: add `'@typescript-eslint/consistent-type-imports': 'error'`.

No source changes needed — the current `src` tree has **0 violations**, so this is a forward-looking guardrail.

## Verification (local)

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` ✅ (86 tests passing)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)