### PR TITLE
chore(lint): enable no-param-reassign

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,11 @@ export default [
   {
     rules: {
       // Require === and !== to avoid implicit type coercion bugs.
-      eqeqeq: ['error', 'always']
+      eqeqeq: ['error', 'always'],
+      // Disallow reassigning function parameters. Mutating a parameter hides
+      // the original argument, breaks referential reasoning, and is a common
+      // source of subtle bugs in parsing/transform code.
+      'no-param-reassign': ['error', { props: false }]
     }
   },
   {


### PR DESCRIPTION
Closes #9

## Summary

Enables the ESLint `no-param-reassign` rule (`['error', { props: false }]`) in `eslint.config.mjs`, alongside the existing `eqeqeq` rule.

## Why

Reassigning a function parameter hides the original argument and breaks referential reasoning — a common bug source in parsing/transform code like this driver. With `props: false`, mutating the contents of an object/array argument is still allowed; only rebinding the parameter identifier is flagged. Conservative and low-noise.

## Change

```diff
   rules: {
     // Require === and !== to avoid implicit type coercion bugs.
-    eqeqeq: ['error', 'always']
+    eqeqeq: ['error', 'always'],
+    // Disallow reassigning function parameters.
+    'no-param-reassign': ['error', { props: false }]
   }
```

## Verification (local)

- `pnpm lint` → pass, **0 violations** (codebase already conforms)
- `pnpm typecheck` → pass
- `pnpm test` → **86 passed**
- `pnpm build` → pass

No source changes were needed; this is a preventive guard. One rule, config-only, fully reviewable.

---
*This pull request was opened by the "Add lint rule → issue + PR (owned repos + my orgs) → Slack" routine of moadim.* cc @tupe12334