### PR TITLE
chore(lint): enable no-implicit-coercion rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,10 @@ export default [
   {
     rules: {
       // Require === and !== to avoid implicit type coercion bugs.
-      eqeqeq: ['error', 'always']
+      eqeqeq: ['error', 'always'],
+      // Disallow shorthand type coercions (!!x, +x, '' + x) in favor of
+      // explicit Boolean(x)/Number(x)/String(x) for clearer, safer conversions.
+      'no-implicit-coercion': 'error'
     }
   },
   {


### PR DESCRIPTION
Closes #11

## What
Enables the ESLint [`no-implicit-coercion`](https://eslint.org/docs/latest/rules/no-implicit-coercion) rule (`error`) in `eslint.config.mjs`.

## Why
Bans shorthand type-coercion tricks (`!!x`, `+x`, `'' + x`, `~arr.indexOf()`) in favor of explicit `Boolean()` / `Number()` / `String()`. This improves readability and avoids a common class of subtle coercion bugs. It complements the `eqeqeq` rule already enabled here — both fight implicit type coercion.

## Change
```diff
       eqeqeq: ['error', 'always'],
+      'no-implicit-coercion': 'error'
```

## Verification
The codebase has **zero** existing violations, so this is a pure config change with no code churn.

- `pnpm run lint` ✅
- `pnpm run typecheck` ✅
- `pnpm run test` ✅ (86 tests)
- `pnpm run build` ✅

@tupe12334

---
*This pull request was opened by the "Add lint rule → issue + PR (owned repos + my orgs) → Slack" routine of moadim.*