### PR TITLE
chore(lint): enable @typescript-eslint/no-unused-vars

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,17 @@ export default [
   {
     rules: {
       // Require === and !== to avoid implicit type coercion bugs.
-      eqeqeq: ['error', 'always']
+      eqeqeq: ['error', 'always'],
+      // Flag unused variables, imports and arguments to catch dead code.
+      // Names prefixed with `_` are treated as intentionally unused.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
     }
   },
   {


### PR DESCRIPTION
## Summary

Enables the [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) rule as `error` in `eslint.config.mjs`. The shared `eslint-config-agent` preset disables it (`off`), so unused bindings currently go uncaught.

## What it catches

- Unused local variables and function parameters
- Unused (dead) imports
- Variables assigned but never read — often a real logic bug

Intentionally-unused names can opt out with a leading `_` (`argsIgnorePattern` / `varsIgnorePattern` / `caughtErrorsIgnorePattern`).

## Verification

The `src/` tree is already clean under this rule — **zero** new violations. Locally:

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (86 tests)

Pure guardrail for future changes; no source edits required.

Closes #13

---
_This pull request was opened by the "Add lint rule → issue + PR (owned repos + my orgs) → Slack" routine of moadim. cc @tupe12334_