### PR TITLE
chore(lint): enable @typescript-eslint/no-non-null-assertion

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,10 @@ export default [
   {
     rules: {
       // Require === and !== to avoid implicit type coercion bugs.
-      eqeqeq: ['error', 'always']
+      eqeqeq: ['error', 'always'],
+      // Forbid non-null assertions (`x!`) which silence the compiler and can
+      // hide real null/undefined values that crash at runtime.
+      '@typescript-eslint/no-non-null-assertion': 'error'
     }
   },
   {

--- a/src/storage-operations.test.ts
+++ b/src/storage-operations.test.ts
@@ -124,7 +124,8 @@ describe("Storage Operations", () => {
         toRemove: "value"
       });
 
-      await operations.setItem("toRemove", null!, {});
+      // Pass null to exercise the key-removal branch.
+      await operations.setItem("toRemove", null, {});
 
       expect(mockUpdateUrl).toHaveBeenCalledWith({ foo: "bar" });
     });

--- a/src/storage-operations.ts
+++ b/src/storage-operations.ts
@@ -40,7 +40,7 @@ export function createStorageOperations(
       return value === null ? null : String(value)
     },
 
-    setItem: (key: string, value: string, _opts: TransactionOptions): Promise<void> => {
+    setItem: (key: string, value: string | null, _opts: TransactionOptions): Promise<void> => {
       try {
         const data = dataManager.getCurrentData(basePrefix)
         const newData = value === null || value === undefined


### PR DESCRIPTION
## Summary
Enables the `@typescript-eslint/no-non-null-assertion` lint rule (set to `error`) to forbid non-null assertions (`value!`).

A non-null assertion silences the compiler's null-safety check at that spot. When the assumption is wrong, the code throws at runtime — the exact bug class TypeScript exists to prevent. For a published library, banning it means stronger null-safety guarantees for consumers.

## Changes
- `eslint.config.mjs` — enable `@typescript-eslint/no-non-null-assertion: 'error'`.
- `src/storage-operations.ts` — widen `setItem` signature from `value: string` to `value: string | null`. The implementation already handled `null` (the key-removal branch); the type was simply too narrow.
- `src/storage-operations.test.ts` — drop the now-unnecessary `null!` assertion; pass `null` directly.

## Verification
- `pnpm lint` — passes (rule active, zero violations)
- `pnpm typecheck` — passes
- `pnpm test` — 86/86 pass
- `pnpm build` — succeeds

Closes #15

---
This pull request was opened by the *Add lint rule → issue + PR (owned repos + my orgs) → Slack* routine of moadim.
cc @tupe12334
