### PR TITLE
chore(lint): enable no-console rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,13 @@ export default [
   {
     rules: {
       // Require === and !== to avoid implicit type coercion bugs.
-      eqeqeq: ['error', 'always']
+      eqeqeq: ['error', 'always'],
+      // Disallow stray `console` calls in this published driver. Debug logs
+      // that slip into the package pollute consumers' browser/server output
+      // and can leak internal state; `console.warn`/`console.error` stay
+      // allowed for the driver's legitimate diagnostics (e.g. the URL-length
+      // warning in url-updater.ts).
+      'no-console': ['error', { allow: ['warn', 'error'] }]
     }
   },
   {


### PR DESCRIPTION
## What
Enable the ESLint [`no-console`](https://eslint.org/docs/latest/rules/no-console) rule for `src`, configured as `['error', { allow: ['warn', 'error'] }]`.

## Why
This is a **published** unstorage driver. Forgotten `console.log`/`debug`/`info` calls in shipped code pollute consumers' console/log output and can leak internal state. Linting against them keeps the package quiet by default, while `console.warn`/`console.error` remain allowed for genuine diagnostics (the driver already uses `console.warn` for the URL-length warning in `src/url-updater.ts`).

## Change
- `eslint.config.mjs`: add `'no-console': ['error', { allow: ['warn', 'error'] }]` alongside the existing `eqeqeq` rule. Single-rule, config-only change — no other rules touched.

## Verification (local)
- `pnpm lint` → pass (0 violations)
- `pnpm typecheck` → pass
- `pnpm test` → 86 passed
- `pnpm build` → success

Closes #17

---
_This pull request was opened by the "Add lint rule → issue + PR (owned repos + my orgs) → Slack" routine of moadim. cc @tupe12334_