### PR TITLE
chore(lint): enable @typescript-eslint/consistent-type-imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,12 @@ export default [
       // and can leak internal state; `console.warn`/`console.error` stay
       // allowed for the driver's legitimate diagnostics (e.g. the URL-length
       // warning in url-updater.ts).
-      'no-console': ['error', { allow: ['warn', 'error'] }]
+      'no-console': ['error', { allow: ['warn', 'error'] }],
+      // Force imports used only as types to be written `import type { ... }`.
+      // Type-only imports are erased at build time, so marking them keeps the
+      // emitted bundle free of phantom runtime imports, prevents accidental
+      // value/type coupling, and documents intent at the import site.
+      '@typescript-eslint/consistent-type-imports': 'error'
     }
   },
   {


### PR DESCRIPTION
## What

Enables [`@typescript-eslint/consistent-type-imports`](https://typescript-eslint.io/rules/consistent-type-imports/) (set to `error`) in `eslint.config.mjs`.

It enforces that imports used **only as types** are written with `import type { ... }` rather than a plain `import`.

## Why

Type-only imports are erased at build time. Enforcing the `import type` form keeps the emitted bundle free of phantom runtime imports, prevents accidental value/type coupling, and documents intent at the import site.

The `src` tree already follows this convention everywhere, so this rule is a clean no-op that **locks in** the existing style and prevents future regressions (verified the rule does engage via a temporary probe file).

## Verification

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` — 86 tests pass ✅
- `pnpm build` ✅

Closes #7

---
This pull request was opened by the "Open issues → fix PRs (owned repos + my orgs)" routine of moadim. /cc @tupe12334