### PR TITLE
chore(lint): enable no-throw-literal

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,12 @@ export default [
       // and can leak internal state; `console.warn`/`console.error` stay
       // allowed for the driver's legitimate diagnostics (e.g. the URL-length
       // warning in url-updater.ts).
-      'no-console': ['error', { allow: ['warn', 'error'] }]
+      'no-console': ['error', { allow: ['warn', 'error'] }],
+      // Only allow throwing Error objects. Throwing strings or plain objects
+      // (e.g. `throw 'boom'`) loses the stack trace and breaks `instanceof`
+      // checks for consumers catching this driver's failures. The driver
+      // already throws `QueryStringDriverError` everywhere; this locks that in.
+      'no-throw-literal': 'error'
     }
   },
   {


### PR DESCRIPTION
## Summary
Enables the ESLint `no-throw-literal` rule (error level) in `eslint.config.mjs`.

It forbids throwing non-`Error` values (`throw 'boom'`, `throw { code: 1 }`), which lose the stack trace and break `instanceof` / `.message` handling for consumers catching this driver's failures.

## Changes
- Add `'no-throw-literal': 'error'` to the shared rules block, with a comment explaining the rationale.

## Verification
The driver already throws `QueryStringDriverError` (an `Error` subclass) everywhere — **zero violations**.
- `pnpm run lint` ✅
- `pnpm run build` ✅
- `pnpm run test` ✅ (86 tests passing)

No source changes; no other rules touched.

Closes #20

---
This pull request was opened by the *Add lint rule → issue + PR (owned repos + my orgs) → Slack* routine of moadim. cc @tupe12334