### PR TITLE
chore(lint): enable array-callback-return rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,7 +23,18 @@ export default [
       'no-param-reassign': ['error', { props: false }],
       // Force `import type` for type-only imports so they are erased at
       // compile time and never leak into the runtime bundle.
-      '@typescript-eslint/consistent-type-imports': 'error'
+      '@typescript-eslint/consistent-type-imports': 'error',
+      // Require a `return` value from every array-method callback that is
+      // expected to produce one (`map`, `filter`, `reduce`, `sort`, `every`,
+      // `some`, `flatMap`, etc.). A callback that falls through without
+      // returning yields `undefined`, which silently corrupts the result:
+      // `filter` drops every element, `map` fills the array with `undefined`,
+      // `reduce` throws or accumulates wrong values. This driver parses and
+      // transforms query-string entries through exactly these array methods,
+      // so a missing return is a real correctness bug. `checkForEach` also
+      // flags a `forEach` callback that returns a value, which usually means
+      // the wrong method (`map`/`filter`) was intended.
+      'array-callback-return': ['error', { checkForEach: true }]
     }
   },
   {


### PR DESCRIPTION
Enables the [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return) ESLint rule in the shared `rules` block of `eslint.config.mjs`.

## What
```js
'array-callback-return': ['error', { checkForEach: true }]
```

## Why
Array-method callbacks that are expected to return a value (`map`, `filter`, `reduce`, `sort`, `every`, `some`, `find`, `flatMap`, …) silently return `undefined` when a `return` is forgotten — `filter` drops every element, `map` fills with `undefined`, `reduce` accumulates wrong values. This driver parses and transforms query-string entries through exactly these methods, so a missing return is a genuine correctness bug. `checkForEach: true` also flags a `forEach` callback that returns a value (usually a misused `map`/`filter`).

## Impact
- **Zero existing violations** — pure guardrail, no code churn.
- `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` (86 passed) ✅ · `pnpm build` ✅

Closes #22

---
*This pull request was opened by the "Add lint rule → issue + PR (owned repos + my orgs) → Slack" routine of moadim.*