### PR TITLE
chore(lint): enable consistent-return

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,13 @@ export default [
     rules: {
       // Require === and !== to avoid implicit type coercion bugs.
       eqeqeq: ['error', 'always'],
+      // Require every function's `return` statements to be consistent: either
+      // all of them specify a value or none do. A function that returns a
+      // value on one branch but falls through on another silently yields
+      // `undefined`, which propagates into stored state or URL output in this
+      // parsing/transform driver. This makes accidental fall-through a lint
+      // error and complements `array-callback-return` below.
+      'consistent-return': 'error',
       // Disallow stray `console` calls in this published driver. Debug logs
       // that slip into the package pollute consumers' browser/server output
       // and can leak internal state; `console.warn`/`console.error` stay


### PR DESCRIPTION
Closes #26

## What

Enables the [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) ESLint rule (`error`) in `eslint.config.mjs`.

## Why

`consistent-return` flags functions that return a value on some code paths but fall through (returning `undefined`) on others — a classic correctness bug in this query-string parsing/transform driver, where a silent `undefined` propagates into stored state or URL output. It complements the already-enabled `array-callback-return` rule.

## Change

Single rule added to the existing rules block. No production code changes — the `src` tree already passes with **zero violations**.

## Verification

| Step | Result |
|------|--------|
| `pnpm lint` | ✅ pass (0 errors) |
| `pnpm typecheck` | ✅ pass |
| `pnpm test` | ✅ 86 passed (10 files) |
| `pnpm build` | ✅ built |

---
_This pull request was opened by the "Add lint rule → issue + PR (owned repos + my orgs) → Slack" routine of moadim. cc @tupe12334_