### PR TITLE
chore(lint): enable prefer-template rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,7 +41,21 @@ export default [
       // so a missing return is a real correctness bug. `checkForEach` also
       // flags a `forEach` callback that returns a value, which usually means
       // the wrong method (`map`/`filter`) was intended.
-      'array-callback-return': ['error', { checkForEach: true }]
+      'array-callback-return': ['error', { checkForEach: true }],
+      // Require template literals (`` `${base}?${query}` ``) instead of string
+      // concatenation with `+` (`base + '?' + query`). The `+` operator is
+      // overloaded for both numeric addition and string concatenation, so a
+      // single non-string operand silently flips the meaning of the whole
+      // expression: `'?' + a + b` where `a`/`b` are numbers concatenates, while
+      // `a + b + '?'` adds first — a subtle coercion bug that is easy to write
+      // in a driver whose entire job is assembling URL/query strings out of
+      // mixed keys and values. Template literals always stringify and read
+      // left-to-right without juggling quotes and `+`, keeping one clear idiom
+      // for building the strings this package emits. The rule is auto-fixable,
+      // so it stays low-risk as the driver grows. The `src` tree already uses
+      // template literals everywhere, so there are no violations today — this
+      // simply locks the existing pattern in.
+      'prefer-template': 'error'
     }
   },
   {


### PR DESCRIPTION
## What

Enables the [`prefer-template`](https://eslint.org/docs/latest/rules/prefer-template)
ESLint rule at `error` in `eslint.config.mjs`.

## Why

`prefer-template` forbids string building with the `+` operator
(`base + '?' + query`) and requires template literals
(`` `${base}?${query}` ``). `+` is overloaded for numeric addition and string
concatenation, so one non-string operand silently flips the meaning of the
expression — a real coercion footgun for a driver whose job is assembling URL
and query strings from mixed keys/values. Template literals always stringify and
read left-to-right, keeping one clear idiom for the strings this package emits.
It complements the error-handling/correctness rules already enabled here
(`array-callback-return`, `consistent-return`, `no-throw-literal`, `eqeqeq`).

## Risk

- Type-unaware, **auto-fixable** core rule.
- `src` already uses template literals throughout → **zero current violations**;
  this locks the existing pattern in.

## Verification

- `pnpm lint` — passes (no new errors)
- `pnpm typecheck` — passes
- `pnpm test` — 86/86 passing
- `pnpm build` — succeeds

Single rule, single config line. No other rules changed.

Closes #29

---
*This pull request was opened by the "Add lint rule → issue + PR (owned repos + my orgs) → Slack" routine of moadim.*
