### PR TITLE
chore: add block-no-verify Claude Code hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `.claude/settings.json` wiring up [`block-no-verify`](https://www.npmjs.com/package/block-no-verify) as a `PreToolUse` hook on `Bash` commands.
- Blocks Claude Code (or other agents) from bypassing git hooks via `git commit --no-verify` / `git push --no-verify`.

This pull request was opened by the "Add block-no-verify hook to a repo" routine of moadim.

## Test plan
- [x] Confirmed via `npm view block-no-verify` that the package's documented usage is a `PreToolUse` hook running `npx block-no-verify`.
- [x] Verified no existing `.claude/settings.json` or block-no-verify hook was present in this repo prior to this change.